### PR TITLE
feat: add possibility to include a prefix to all metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The 2nd line is the final set of labels after merging `options.ext.pushgateway` 
 
 # Metrics prefix
 
-It is possible to configure this output to expose time series with a prefix.
+It is possible to configure this output to expose the time series with a prefix.
 
 Configure it with the following environment variable:
 

--- a/README.md
+++ b/README.md
@@ -45,3 +45,13 @@ DEBU[0000] Pushgateway labels map[app:MYAPP env:MYENV url:MYURL]
 The 1st line is Prometheus labels from `options.ext.pushgateway` dictionary.
 
 The 2nd line is the final set of labels after merging `options.ext.pushgateway` dictionary and environment variables.
+
+# Metrics prefix
+
+It is possible to configure this output to expose time series with a prefix.
+
+Configure it with the following environment variable:
+
+```
+K6_PUSHGATEWAY_NAMESPACE=k6 k6 run ...
+```

--- a/pkg/pushgateway/collector_resolver/resolver.go
+++ b/pkg/pushgateway/collector_resolver/resolver.go
@@ -17,7 +17,7 @@ import (
 // [k6 metric type]: https://k6.io/docs/using-k6/metrics/#metric-types
 // [conversion rule]: https://k6.io/blog/k6-loves-prometheus/#mapping-k6-metrics-types
 // [xk6-output-prometheus-remote]: https://github.com/grafana/xk6-output-prometheus-remote
-type CollectorResolver func(sample metrics.Sample, labels prometheus.Labels) []prometheus.Collector
+type CollectorResolver func(sample metrics.Sample, labels prometheus.Labels, prefix string) []prometheus.Collector
 
 // CreateResolveer is a factory method to create the [ColloectorResolver] implementation
 // corresponding to the given [k6 metric type].
@@ -43,10 +43,10 @@ func CreateResolver(t metrics.MetricType) CollectorResolver {
 	return resolver
 }
 
-func resolveCounter(sample metrics.Sample, labels prometheus.Labels) []prometheus.Collector {
+func resolveCounter(sample metrics.Sample, labels prometheus.Labels, prefix string) []prometheus.Collector {
 	counter := prometheus.NewCounterFunc(
 		prometheus.CounterOpts{
-			Name:        sample.Metric.Name,
+			Name:        getPrefixedName(prefix, sample.Metric.Name),
 			ConstLabels: labels,
 		},
 		func() float64 {
@@ -57,10 +57,10 @@ func resolveCounter(sample metrics.Sample, labels prometheus.Labels) []prometheu
 	return []prometheus.Collector{counter}
 }
 
-func resolveGauge(sample metrics.Sample, labels prometheus.Labels) []prometheus.Collector {
+func resolveGauge(sample metrics.Sample, labels prometheus.Labels, prefix string) []prometheus.Collector {
 	gauge := prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
-			Name:        sample.Metric.Name,
+			Name:        getPrefixedName(prefix, sample.Metric.Name),
 			ConstLabels: labels,
 		},
 		func() float64 {
@@ -70,10 +70,10 @@ func resolveGauge(sample metrics.Sample, labels prometheus.Labels) []prometheus.
 	return []prometheus.Collector{gauge}
 }
 
-func resolveRate(sample metrics.Sample, labels prometheus.Labels) []prometheus.Collector {
+func resolveRate(sample metrics.Sample, labels prometheus.Labels, prefix string) []prometheus.Collector {
 	gauge := prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
-			Name:        sample.Metric.Name,
+			Name:        getPrefixedName(prefix, sample.Metric.Name),
 			ConstLabels: labels,
 		},
 		func() float64 {
@@ -83,7 +83,7 @@ func resolveRate(sample metrics.Sample, labels prometheus.Labels) []prometheus.C
 	return []prometheus.Collector{gauge}
 }
 
-func resolveTrend(sample metrics.Sample, labels prometheus.Labels) []prometheus.Collector {
+func resolveTrend(sample metrics.Sample, labels prometheus.Labels, prefix string) []prometheus.Collector {
 	sink := sample.Metric.Sink.Format(time.Duration(0))
 
 	collectors := make([]prometheus.Collector, 0)
@@ -95,7 +95,7 @@ func resolveTrend(sample metrics.Sample, labels prometheus.Labels) []prometheus.
 		name := fmt.Sprintf("%s_%s", sample.Metric.Name, suffix)
 		gauge := prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name:        name,
+				Name:        getPrefixedName(prefix, name),
 				ConstLabels: labels,
 			},
 		)
@@ -103,4 +103,12 @@ func resolveTrend(sample metrics.Sample, labels prometheus.Labels) []prometheus.
 		collectors = append(collectors, gauge)
 	}
 	return collectors
+}
+
+func getPrefixedName(prefix string, name string) string {
+	if prefix == "" {
+		return name
+	}
+
+	return fmt.Sprintf("%s_%s", prefix, name)
 }

--- a/pkg/pushgateway/collector_resolver/resolver_test.go
+++ b/pkg/pushgateway/collector_resolver/resolver_test.go
@@ -66,7 +66,7 @@ func TestResolveCounter(t *testing.T) {
 	}
 
 	// When
-	collectors := resolveCounter(sample, nil)
+	collectors := resolveCounter(sample, nil, "")
 
 	// Then
 	if len(collectors) != 1 {
@@ -131,7 +131,7 @@ func TestResolveGauge(t *testing.T) {
 	}
 
 	// When
-	collectors := resolveGauge(sample, nil)
+	collectors := resolveGauge(sample, nil, "")
 
 	// Then
 	if len(collectors) != 1 {
@@ -193,7 +193,7 @@ func TestResolveRate(t *testing.T) {
 	}
 
 	// When
-	collectors := resolveRate(sample, nil)
+	collectors := resolveRate(sample, nil, "")
 
 	// Then
 	if len(collectors) != 1 {
@@ -261,7 +261,7 @@ func TestResolveTrent(t *testing.T) {
 	}
 
 	// When
-	collectors := resolveTrend(sample, nil)
+	collectors := resolveTrend(sample, nil, "")
 
 	// Then
 	if len(collectors) != 6 {

--- a/pkg/pushgateway/config.go
+++ b/pkg/pushgateway/config.go
@@ -15,6 +15,7 @@ const (
 	defaultPushGWUrl    = "http://localhost:9091"
 	defaultPushInterval = 10 * time.Second
 	defaultJobName      = "k6_load_testing"
+	defaultNamespace    = ""
 )
 
 // Config is the config for the template collector
@@ -23,6 +24,9 @@ type Config struct {
 	Labels       map[string]string
 	PushGWUrl    string
 	PushInterval time.Duration
+
+	// Used to prefix all tags with a custom namespace
+	Namespace string
 }
 
 // NewConfig creates a new Config instance from the provided output.Params
@@ -32,6 +36,7 @@ func NewConfig(p output.Params) (Config, error) {
 		Labels:       map[string]string{},
 		PushGWUrl:    defaultPushGWUrl,
 		PushInterval: defaultPushInterval,
+		Namespace:    defaultNamespace,
 	}
 
 	if val, ok := p.ScriptOptions.External["pushgateway"]; ok {
@@ -59,6 +64,8 @@ func NewConfig(p output.Params) (Config, error) {
 			}
 		case "K6_PUSHGATEWAY_URL":
 			cfg.PushGWUrl = v
+		case "K6_PUSHGATEWAY_NAMESPACE":
+			cfg.Namespace = v
 		case "K6_JOB_NAME":
 			cfg.JobName = v
 		}

--- a/pkg/pushgateway/output.go
+++ b/pkg/pushgateway/output.go
@@ -116,12 +116,8 @@ func extractPushSamples(sampleContainers []metrics.SampleContainer) map[string]m
 func (o *Output) convertk6SamplesToPromCollectors(samplesMap map[string]metrics.Sample, labels prometheus.Labels) []prometheus.Collector {
 	collectors := make([]prometheus.Collector, 0)
 	for _, sample := range samplesMap {
-		if o.config.Namespace != "" {
-			sample.Metric.Name = o.config.Namespace + "_" + sample.Metric.Name
-		}
-
 		resolver := collector_resolver.CreateResolver(sample.Metric.Type)
-		collectors = append(collectors, resolver(sample, labels)...)
+		collectors = append(collectors, resolver(sample, labels, o.config.Namespace)...)
 	}
 	return collectors
 }

--- a/pkg/pushgateway/output.go
+++ b/pkg/pushgateway/output.go
@@ -84,7 +84,7 @@ func (o *Output) flushMetrics() {
 		sampleMap := extractPushSamples(sampleContainers)
 		o.logger.WithFields(dumpk6Sample(sampleMap)).Debug("Dump k6 samples.")
 		labels := o.GetLabels()
-		collectors := o.convertk6SamplesToPromCollectors(sampleMap, labels)
+		collectors := convertk6SamplesToPromCollectors(sampleMap, labels, o.config.Namespace)
 
 		registry := prometheus.NewPedanticRegistry()
 		registry.MustRegister(collectors...)
@@ -113,11 +113,11 @@ func extractPushSamples(sampleContainers []metrics.SampleContainer) map[string]m
 	return sampleMap
 }
 
-func (o *Output) convertk6SamplesToPromCollectors(samplesMap map[string]metrics.Sample, labels prometheus.Labels) []prometheus.Collector {
+func convertk6SamplesToPromCollectors(samplesMap map[string]metrics.Sample, labels prometheus.Labels, prefix string) []prometheus.Collector {
 	collectors := make([]prometheus.Collector, 0)
 	for _, sample := range samplesMap {
 		resolver := collector_resolver.CreateResolver(sample.Metric.Type)
-		collectors = append(collectors, resolver(sample, labels, o.config.Namespace)...)
+		collectors = append(collectors, resolver(sample, labels, prefix)...)
 	}
 	return collectors
 }


### PR DESCRIPTION
The prometheus remote write output from K6 already exposes all metrics with a prefix: https://k6.io/docs/results-output/real-time/prometheus-remote-write/

I think this extension should be able to configure it too (even tho I let it empty by default).

Non-related question: shouldn't trend be a histogram?